### PR TITLE
Enable Modbus/TCP proxy by default

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -32,7 +32,8 @@
 
 // Enable a Modbus/TCP proxy on the stick. When enabled the device listens on
 // MODBUS_TCP_PORT (default 502) and forwards requests to the inverter.
-#define MODBUS_TCP_PROXY 0
+// Comment out to use the default value from the application.
+#define MODBUS_TCP_PROXY 1
 #define MODBUS_TCP_PORT 502
 
 // Define a NTP Server and TZ Info to automatically adjust the inverter date/time.

--- a/SRC/ShineWiFi-ModBus/ModbusTcpProxy.h
+++ b/SRC/ShineWiFi-ModBus/ModbusTcpProxy.h
@@ -1,7 +1,16 @@
 #pragma once
 
+
 #include "Growatt.h"
 #include "ShineWifi.h"
+
+#ifndef MODBUS_TCP_PROXY
+#define MODBUS_TCP_PROXY 1
+#endif
+
+#ifndef MODBUS_TCP_PORT
+#define MODBUS_TCP_PORT 502
+#endif
 
 #if MODBUS_TCP_PROXY == 1
 void ModbusTcpProxySetup();


### PR DESCRIPTION
## Summary
- default `MODBUS_TCP_PROXY` to `1`
- allow override via `Config.h`
- document new default in `Config.h.example`

## Testing
- `pio` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840be67874c832aa6133a30fccc1539