### PR TITLE
Add HTTP register table dump

### DIFF
--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -89,6 +89,7 @@ copies or substantial portions of the Software. -->
         <a href="./status" class="linkButton">Json</a>
         <a href="./uiStatus" class="linkButton">UI Json</a>
         <a href="./metrics" class="linkButton">Metrics</a>
+        <a href="./registers" class="linkButton">Registers</a>
         <a href="./debug" class="linkButton">Log</a>
         <a onClick="return confirm('Starting config AP will disconnect you from the device. Are you sure?');" href="./startAp" class="linkButton yellow">Start Config AP</a>
         <a onClick="return confirm('This will reboot the Wifi Stick. Are you sure?');" href="./reboot" class="linkButton yellow">Reboot</a>


### PR DESCRIPTION
## Summary
- add `/registers` HTTP endpoint to dump all registers as hex table
- link new page from main UI
- skip registers that repeatedly fail to respond and label them as dead

## Testing
- `clang-format --version`


------
https://chatgpt.com/codex/tasks/task_b_68523d200858832abe03102c69fcc7a4